### PR TITLE
Parameters in ContentType header shouldn't affect payload hash

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -177,7 +177,7 @@ func TestClient_Authenticate(t *testing.T) {
 
 	// POST
 	var mockedHttpServer1 = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("Server-Authorization", `Hawk mac="odsVGUq0rCoITaiNagW22REIpqkwP9zt5FyqqOW9Zj8=", hash="f9cDF/TDm7TkYRLnGwRMfeDzT6LixQVLvrIKhh0vgmM=", ext="response-specific"`)
 		fmt.Fprintf(w, "\n")
 	})

--- a/crypto.go
+++ b/crypto.go
@@ -87,10 +87,14 @@ func (h *PayloadHash) String() string {
 	return base64.StdEncoding.EncodeToString(hash)
 }
 
+func sanitizeContentType(contentType string) string {
+	return strings.TrimSpace(strings.ToLower(strings.Split(contentType, ";")[0]))
+}
+
 func (h *PayloadHash) hash() []byte {
 	s := getHash(h.Alg)()
 
-	ns := "hawk." + strconv.Itoa(headerVersion) + ".payload" + "\n" + strings.ToLower(h.ContentType) + "\n" + h.Payload + "\n"
+	ns := "hawk." + strconv.Itoa(headerVersion) + ".payload" + "\n" + sanitizeContentType(h.ContentType) + "\n" + h.Payload + "\n"
 	s.Write([]byte(ns))
 
 	return s.Sum(nil)

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -152,4 +152,17 @@ func TestPayloadHash_String(t *testing.T) {
 	if actual != expect {
 		t.Error("invalid payload hash string.")
 	}
+
+	h2 := &PayloadHash{
+		ContentType: "text/plain; charset=utf-8",
+		Payload:     "Thank you for flying Hawk",
+		Alg:         SHA256,
+	}
+
+	// expected value shouldn't change from ContentType changing
+	actual2 := h2.String()
+
+	if actual2 != expect {
+		t.Error("invalid payload hash string when given ContentType with parameters.")
+	}
 }


### PR DESCRIPTION
## Description

From the Hawk spec site (https://github.com/hapijs/hawk):
 
```
Payload Validation
Hawk provides optional payload validation. When generating the authentication header, the client calculates a payload hash using the specified hash algorithm. The hash is calculated over the concatenated value of (each followed by a newline character):
 
·         hawk.1.payload
·         the content-type in lowercase, without any parameters (e.g. application/json)
·         the request payload prior to any content encoding (the exact representation requirements should be specified by the server for payloads other than simple single-part ascii to ensure interoperability)
```

Attention to the second bullet point's `without any parameters`

## Testing

```
go test ./...
ok      github.com/infacloud/hawk       0.025s
```